### PR TITLE
update Cyberduck bookmark location for the sandboxed & later versions

### DIFF
--- a/mackup/applications/cyberduck.cfg
+++ b/mackup/applications/cyberduck.cfg
@@ -2,5 +2,8 @@
 name = Cyberduck
 
 [configuration_files]
+# based on https://trac.cyberduck.io/wiki/help/en/faq#Preferencesandapplicationsupportfileslocation
 Library/Application Support/Cyberduck
+Library/Containers/ch.sudo.cyberduck/Data/Library/Application Support/Cyberduck
+Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck
 Library/Preferences/ch.sudo.cyberduck.plist


### PR DESCRIPTION
New versions of Cyberduck has a different preference file location. This PR reflects this changes, which is based on CyberDuck's own FAQ entry:

https://trac.cyberduck.io/wiki/help/en/faq#Preferencesandapplicationsupportfileslocation

Tested and worked in MacOS Sierra. See screenshot below:

https://www.dropbox.com/s/bv54v8slga786aq/Tangkapan%20layar%202017-01-30%2014.03.56.png?dl=0